### PR TITLE
Fixes the attendance page for Teams so that parameters can be changed

### DIFF
--- a/HTMLTemplates/team_attendance.mako
+++ b/HTMLTemplates/team_attendance.mako
@@ -8,7 +8,7 @@
 ${self.logo()}<br/>
 <H1>${team_name}</H1>
 
-<form action="teamAttendance">
+<form action="attendance">
   <fieldset>
     <legend>See who was here during a team meeting</legend>
     <br/>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,41 @@ You'll need a python venv, set it up like this:
   1. ```python3 -m venv venv```
   2. ```source venv/bin/activate```
   3. ```pip install -r requirements.txt```
-
-You'll also need a ```sessions``` directory to store session data
+  4. ```mkdir testData```
+  5. ```echo "l1n5Be5G9GHFXTSMi6tb0O6o5AKmTC68OjF2UmaU55A=" > testData/checkmein.key```
+  6. ```mkdir sessions```
+* see section: Temporary notes for trouble shooting below if you are on pi
 
 ## Running tests
 To make sure you haven't broken anything where it will crash, run the tests using:
-  python -m pytest tests
+  ```python -m pytest tests```
+
+If a test fails and you want to eliminate it temporarily, rename it to not end in "py". For example,
+```mv tests/sampleTest.py tests/sampleTest.py.ignore```
+DO NOT push these renamed files to the origin repository.
+
+## Launching the server on your test platform
+Once you are satisfied that you have the dependencies met, and the unit tests are passing, then to run the
+server, you will execute:
+
+```python3 checkmein.py development.conf```
+
+You can connect to your server using a local browser at "http://localhost:8089"
+Note: 
+* When first starting, assuming you ran the tests, you may choose to
+```mkdir data```
+```cp testData test.db data/checkmein.db```
+This gives you a database with a couple of members and an admin user whose name 
+is 'admin' and password is 'password'. 
+
+We may want to build a command line tool that takes something like some kind of sqlite "markdown" 
+and populates the database to make playing with capabilities easier. (not hard to do that)
+
+Along these lines , it is handy to
+```sudo apt install sqlitebrowswer```
+because one can view the database contents using this tool.
+
+## Temporary notes for trouble shooting
+* On recent releases of Raspberry Pi OS, it may be necessary to
+```sudo apt install libatlas-base-dev```
+to get numpy to work in python3.


### PR DESCRIPTION
Addresses Issue #46 

When one is on the attendance page 
'{host}.com/teams/attendance?{ parameters }`
and changed the dates/times displayed on the page
and then hit the "see" button, a 404 traceback resulted.

`404 Not Found
The path '/teams/teamAttendance' was not found.

Traceback (most recent call last):
  File "/home/tfi/CheckMeIn/venv3/lib/python3.8/site-packages/cherrypy/_cprequest.py", line 638, in respond
    self._do_respond(path_info)
  File "/home/tfi/CheckMeIn/venv3/lib/python3.8/site-packages/cherrypy/_cprequest.py", line 697, in _do_respond
    response.body = self.handler()
  File "/home/tfi/CheckMeIn/venv3/lib/python3.8/site-packages/cherrypy/lib/encoding.py", line 219, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/home/tfi/CheckMeIn/venv3/lib/python3.8/site-packages/cherrypy/_cperror.py", line 416, in __call__
    raise self
cherrypy._cperror.NotFound: (404, "The path '/teams/teamAttendance' was not found.")`

Problem exists because the button links to a route "teamAttendance" rather than
the correct route of "attendance". After this fix, the pytests
pass and changing the parameters on the attendance page results
in the expected behavior.

Note to alan412 - do you want an issue created in advance for this kind of thing? Feels like that would just lead to confusion about who is going to fix it, but happy to create issues on the alan412 repo if that helps. I'm not sure how that works for repos where one isn't a "contributor" and therefore may not be assignable on an issue?